### PR TITLE
Fix several permissions issues

### DIFF
--- a/RChat.xcodeproj/project.pbxproj
+++ b/RChat.xcodeproj/project.pbxproj
@@ -535,7 +535,7 @@
 				TargetAttributes = {
 					501825341E2469C200E9A535 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = G47H383S4Y;
+						DevelopmentTeam = YSHJQA6U2L;
 						ProvisioningStyle = Automatic;
 					};
 					501825481E2469C200E9A535 = {
@@ -943,7 +943,7 @@
 			baseConfigurationReference = 37B61F1CFAB1215008258AF3 /* Pods-RChat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = G47H383S4Y;
+				DEVELOPMENT_TEAM = YSHJQA6U2L;
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;
@@ -957,7 +957,7 @@
 			baseConfigurationReference = 5DFF720C447BADFD54790C8C /* Pods-RChat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = G47H383S4Y;
+				DEVELOPMENT_TEAM = YSHJQA6U2L;
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;


### PR DESCRIPTION
 - Fixed error in URL in permission change request - was using the naked object server URL w/out the actual realm name (e.g.,
  "realm://138.197.85.79:9080" versus "realm://138.197.85.79/global").
  Side note: This may have exposed a bug on the object  server (filed as https://github.com/realm/realm-object-server/issues/926)

- Added a permission change notifier to track the permission changes and log them to the console

- Moved the try block to only surround the actual permission change call to the management realm rather than hate creation of the change object and permission change notifier