### PR TITLE
Fix search to look for both users AND text in your chats

### DIFF
--- a/RChat.xcodeproj/project.pbxproj
+++ b/RChat.xcodeproj/project.pbxproj
@@ -535,7 +535,6 @@
 				TargetAttributes = {
 					501825341E2469C200E9A535 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = YSHJQA6U2L;
 						ProvisioningStyle = Automatic;
 					};
 					501825481E2469C200E9A535 = {
@@ -943,7 +942,7 @@
 			baseConfigurationReference = 37B61F1CFAB1215008258AF3 /* Pods-RChat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = YSHJQA6U2L;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;
@@ -957,7 +956,7 @@
 			baseConfigurationReference = 5DFF720C447BADFD54790C8C /* Pods-RChat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = YSHJQA6U2L;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;

--- a/RChat.xcodeproj/project.pbxproj
+++ b/RChat.xcodeproj/project.pbxproj
@@ -535,7 +535,7 @@
 				TargetAttributes = {
 					501825341E2469C200E9A535 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = G47H383S4Y;
+						DevelopmentTeam = YSHJQA6U2L;
 						ProvisioningStyle = Automatic;
 					};
 					501825481E2469C200E9A535 = {
@@ -943,7 +943,7 @@
 			baseConfigurationReference = 37B61F1CFAB1215008258AF3 /* Pods-RChat.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = G47H383S4Y;
+				DEVELOPMENT_TEAM = YSHJQA6U2L;
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;
@@ -957,7 +957,7 @@
 			baseConfigurationReference = 5DFF720C447BADFD54790C8C /* Pods-RChat.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = G47H383S4Y;
+				DEVELOPMENT_TEAM = YSHJQA6U2L;
 				INFOPLIST_FILE = RChat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Maximilian.RChat;

--- a/RChat/ChatMessage.swift
+++ b/RChat/ChatMessage.swift
@@ -42,4 +42,10 @@ extension ChatMessage {
         }
     }
 
+    
+    static func searchInChats(searchTerm: String) -> Results<ChatMessage> {
+        let realm = RChatConstants.Realms.global        
+        let predicate = NSPredicate(format: "text contains[c] %@", searchTerm)
+        return realm.objects(ChatMessage.self).filter(predicate)
+    }
 }

--- a/RChat/Conversation.swift
+++ b/RChat/Conversation.swift
@@ -39,28 +39,11 @@ class Conversation : Object {
 extension Conversation {
 
     static func searchForConversations(searchTerm: String) -> Results<Conversation> {
-        var conversationIds = [String]()
         let realm = RChatConstants.Realms.global
         
-        // the old version was looking as the user's display name... not thru the chat message text
-        //let predicate = NSPredicate(format: "displayName contains[c] %@", searchTerm, searchTerm, RChatConstants.myUserId)
-        //return realm.objects(Conversation.self).filter(predicate)
+        let predicate = NSPredicate(format: "displayName contains[c] %@", searchTerm)
+        return realm.objects(Conversation.self).filter(predicate)
 
-        // messages with the search term to which I am party
-        let predicate = NSPredicate(format: "text contains[c] %@  AND userId = %@", searchTerm, RChatConstants.myUserId)
-        let results = realm.objects(ChatMessage.self).filter(predicate)
-        
-        // this is a little ugly, for some reason using map() on a list of Realm <results> doesn't 
-        // seem to work as I expect - so realm.objects(ChatMessage.self).filter(predicate).map{$0.conversationId}
-        // returns a list of objects rather than the list of conversationId's
-        //
-        results.forEach { (chatMessage) in // gather the conversationId's
-            conversationIds.append(chatMessage.conversationId)
-        }
-        
-        conversationIds = Array(Set(conversationIds)) // unique them
-        
-        return realm.objects(Conversation.self).filter("conversationId in %@", conversationIds)
     }
 
     static func generateDirectMessage(userId1: String, userId2: String) -> String {

--- a/RChat/Conversation.swift
+++ b/RChat/Conversation.swift
@@ -39,9 +39,28 @@ class Conversation : Object {
 extension Conversation {
 
     static func searchForConversations(searchTerm: String) -> Results<Conversation> {
+        var conversationIds = [String]()
         let realm = RChatConstants.Realms.global
-        let predicate = NSPredicate(format: "displayName contains[c] %@", searchTerm, searchTerm, RChatConstants.myUserId)
-        return realm.objects(Conversation.self).filter(predicate)
+        
+        // the old version was looking as the user's display name... not thru the chat message text
+        //let predicate = NSPredicate(format: "displayName contains[c] %@", searchTerm, searchTerm, RChatConstants.myUserId)
+        //return realm.objects(Conversation.self).filter(predicate)
+
+        // messages with the search term to which I am party
+        let predicate = NSPredicate(format: "text contains[c] %@  AND userId = %@", searchTerm, RChatConstants.myUserId)
+        let results = realm.objects(ChatMessage.self).filter(predicate)
+        
+        // this is a little ugly, for some reason using map() on a list of Realm <results> doesn't 
+        // seem to work as I expect - so realm.objects(ChatMessage.self).filter(predicate).map{$0.conversationId}
+        // returns a list of objects rather than the list of conversationId's
+        //
+        results.forEach { (chatMessage) in // gather the conversationId's
+            conversationIds.append(chatMessage.conversationId)
+        }
+        
+        conversationIds = Array(Set(conversationIds)) // unique them
+        
+        return realm.objects(Conversation.self).filter("conversationId in %@", conversationIds)
     }
 
     static func generateDirectMessage(userId1: String, userId2: String) -> String {

--- a/RChat/SearchResultTableViewCell.swift
+++ b/RChat/SearchResultTableViewCell.swift
@@ -43,4 +43,13 @@ class SearchResultTableViewCell: UITableViewCell {
     func setupWithConversation(conversation: Conversation){
         label.text = conversation.defaultingName
     }
+    
+    // Added support for searching inside chats
+    func setupWithChat(chat: ChatMessage){
+        let realm = RChatConstants.Realms.global
+        let conversation = realm.objects(Conversation.self).filter("conversationId = %@", chat.conversationId).first
+        label.text = conversation!.defaultingName
+    }
+    
+
 }

--- a/RChat/SearchResultTableViewCell.swift
+++ b/RChat/SearchResultTableViewCell.swift
@@ -37,18 +37,18 @@ class SearchResultTableViewCell: UITableViewCell {
     }
 
     func setupWithUser(user: User){
-        label.text = user.defaultingName
+        label.text = "👤| " + user.defaultingName
     }
 
     func setupWithConversation(conversation: Conversation){
-        label.text = conversation.defaultingName
+        label.text = "👥 | " + conversation.defaultingName
     }
     
     // Added support for searching inside chats
     func setupWithChat(chat: ChatMessage){
         let realm = RChatConstants.Realms.global
         let conversation = realm.objects(Conversation.self).filter("conversationId = %@", chat.conversationId).first
-        label.text = conversation!.defaultingName
+        label.text = "💬 | " + conversation!.defaultingName
     }
     
 

--- a/RChat/SearchResultsViewController.swift
+++ b/RChat/SearchResultsViewController.swift
@@ -20,6 +20,7 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
 
     var conversations : Results<Conversation>?
     var users: Results<User>?
+    var chats: Results<ChatMessage>?
 
     lazy var tableView : UITableView = {
         let t = UITableView()
@@ -46,7 +47,7 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return 3    // Was 2
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -55,6 +56,10 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
             return conversations?.count ?? 0
         case 1:
             return users?.count ?? 0
+            
+        // Added support for searching inside chats
+        case 2:
+            return chats?.count ?? 0
         default:
             return 0
         }
@@ -71,6 +76,12 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
         case 1:
             if let user = users?[indexPath.row] {
                 cell.setupWithUser(user: user)
+            }
+            
+        // Added support for searching inside chats
+        case 2:
+            if let chat = chats?[indexPath.row] {
+                cell.setupWithChat(chat: chat)
             }
         default:
             fatalError("No such section exists")
@@ -95,6 +106,16 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
                 delegate?.selectedSearchedConversation(conversation: conversation)
             }
             return;
+            
+        // Added support for searching inside chats
+        case 2:
+            if let chat = chats?[indexPath.row] {
+                let realm = RChatConstants.Realms.global
+                let conversation = realm.objects(Conversation.self).filter("conversationId = %@", chat.conversationId).first
+                delegate?.selectedSearchedConversation(conversation: conversation!)
+            }
+            return;
+
         default:
             fatalError("No such section exists")
         }
@@ -103,6 +124,10 @@ class SearchResultsViewController: UIViewController, UITableViewDataSource, UITa
     func searchConversationsAndUsers(searchTerm: String){
         conversations = Conversation.searchForConversations(searchTerm: searchTerm)
         users = User.searchForUsers(searchTerm: searchTerm)
+
+        // Added support for searching inside chats
+        chats = ChatMessage.searchInChats(searchTerm: searchTerm)
+
         tableView.reloadData()
     }
 


### PR DESCRIPTION
Fix the conversation search to actually look through the text of the chats the user is party to for the search term.  

Previously it was looking at the chat's display name for the user's named returning those conversations... which was  really no different that looking though the _users list_ for the search term (ostensibly for the user's name)...  which is what the other part of the default search mechanism already does (find users you are  in chats with based on your username).  

I think this was originally a copy-pasta error as Max was writing this, but now it lets you find both users or relevant text in your chats.  